### PR TITLE
we can not remove collada_urdf from .travis.rosinstall.noetic

### DIFF
--- a/.travis.rosinstall.noetic
+++ b/.travis.rosinstall.noetic
@@ -1,3 +1,10 @@
+# find_package(collada_urdf) failed due to wrong collada_urdfConfig.cmake
+# - https://github.com/ros/collada_urdf/issues/43
+# - https://github.com/ros/collada_urdf/pull/44
+- git:
+    local-name: collada_urdf
+    uri: https://github.com/werner291/collada_urdf.git
+    version: patch-1
 # jsk_robot_startup LightweightLogger requires mongodb_store
 # use package.xml format 3 to install python3-pymongo, see https://github.com/strands-project/mongodb_store/pull/269
 - git:


### PR DESCRIPTION
```
  cd /github/home/ros/ws_jsk_robot/build/cobottaeus; catkin build --get-env cobottaeus | catkin env -si  /usr/bin/make --jobserver-auth=6,7; cd -
  
  ...............................................................................
  _______________________________________________________________________________
  Errors << baxtereus:cmake /github/home/ros/ws_jsk_robot/logs/baxtereus/build.cmake.000.log
  CMake Error at /opt/ros/noetic/share/collada_urdf/cmake/collada_urdfConfig.cmake:113 (message):
    Project 'collada_urdf' specifies '/usr/../include/include' as an include
    dir, which is not found.  It does neither exist as an absolute directory
    nor in '${{prefix}}//usr/../include/include'.  Check the issue tracker
    'https://github.com/ros/collada_urdf/issues' and consider creating a ticket
    if the problem has not been reported yet.
  Call Stack (most recent call first):
    /opt/ros/noetic/share/catkin/cmake/catkinConfig.cmake:76 (find_package)
    CMakeLists.txt:10 (find_package)
  
  
  cd /github/home/ros/ws_jsk_robot/build/baxtereus; catkin build --get-env baxtereus | catkin env -si  /usr/bin/cmake /github/home/ros/ws_jsk_robot/src/jsk_robot/jsk_baxter_robot/baxtereus --no-warn-unused-cli -DCATKIN_DEVEL_PREFIX=/github/home/ros/ws_jsk_robot/devel/.private/baxtereus -DCMAKE_INSTALL_PREFIX=/github/home/ros/ws_jsk_robot/install; cd -
```
